### PR TITLE
[Fixes #5] removed check_dependencies task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /target
 coverage
 *.swp
+.ruby-version

--- a/Rakefile
+++ b/Rakefile
@@ -53,8 +53,6 @@ rescue LoadError
   end
 end
 
-task :test => :check_dependencies
-
 task :default => :test
 
 require 'rdoc/task'


### PR DESCRIPTION
Fixes #5, adds .ruby-version to .gitignore so we can use .ruby-version locally for specifying ruby version as we test.
