### PR TITLE
3.days/1.week not properly looking for current implementations

### DIFF
--- a/lib/runt.rb
+++ b/lib/runt.rb
@@ -233,16 +233,16 @@ end
 # somewhere else. :-)
 #
 class Numeric #:nodoc:
-  def microseconds() Float(self  * (10 ** -6)) end unless self.instance_methods.include?('microseconds')
-  def milliseconds() Float(self  * (10 ** -3)) end unless self.instance_methods.include?('milliseconds')
-  def seconds() self end unless self.instance_methods.include?('seconds')
-  def minutes() 60 * seconds end unless self.instance_methods.include?('minutes')
-  def hours() 60 * minutes end unless self.instance_methods.include?('hours')
-  def days() 24 * hours end unless self.instance_methods.include?('days')
-  def weeks() 7 * days end unless self.instance_methods.include?('weeks')
-  def months() 30 * days end unless self.instance_methods.include?('months')
-  def years() 365 * days end unless self.instance_methods.include?('years')
-  def decades() 10 * years end unless self.instance_methods.include?('decades')
+  def microseconds() Float(self  * (10 ** -6)) end unless self.instance_methods.include?(:microseconds)
+  def milliseconds() Float(self  * (10 ** -3)) end unless self.instance_methods.include?(:milliseconds)
+  def seconds() self end unless self.instance_methods.include?(:seconds)
+  def minutes() 60 * seconds end unless self.instance_methods.include?(:minutes)
+  def hours() 60 * minutes end unless self.instance_methods.include?(:hours)
+  def days() 24 * hours end unless self.instance_methods.include?(:days)
+  def weeks() 7 * days end unless self.instance_methods.include?(:weeks)
+  def months() 30 * days end unless self.instance_methods.include?(:months)
+  def years() 365 * days end unless self.instance_methods.include?(:years)
+  def decades() 10 * years end unless self.instance_methods.include?(:decades)
   # This causes RDoc to hurl:
   %w[
   microseconds milliseconds seconds minutes hours days weeks months years decades


### PR DESCRIPTION
instance_methods come back as symbols not strings.  ActiveSupport
implements many of the Numeric shortcuts and return an
"ActiveSupport::Duration" and conflicting with this implementation
(this enables you to say things like 3.days.ago)

